### PR TITLE
feat(stalk): single stalk feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
-    "test:unit": "vitest",
+    "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,7 @@
-<script setup lang="ts">
-import HomeView from './views/HomeView.vue'
-</script>
+<script setup lang="ts" />
 
 <template>
-  <HomeView />
+  <router-view />
 </template>
 
 <style scoped>

--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -1,39 +1,37 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
-import { h } from 'vue'
 import App from '../App.vue'
 
-// Mock the HomeView component to isolate App testing
-vi.mock('../views/HomeView.vue', () => ({
-  default: {
-    name: 'HomeView',
-    render() {
-      return h('div', { class: 'mock-home-view' }, 'Mocked Home View')
-    },
-  },
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  createRouter: vi.fn(),
+  createWebHistory: vi.fn(),
 }))
 
 describe('App', () => {
   it('renders properly with shallow mount', () => {
-    const wrapper = shallowMount(App)
-
-    // With shallowMount, HomeView should be stubbed
-    expect(wrapper.findComponent({ name: 'HomeView' }).exists()).toBe(true)
-  })
-
-  it('contains HomeView when fully mounted', () => {
-    // For this test, we'll use a different approach since we mocked the component
-    // We'll check if the component tries to render HomeView
-
-    const wrapper = mount(App, {
+    const wrapper = shallowMount(App, {
       global: {
         stubs: {
-          HomeView: true,
+          RouterView: true,
         },
       },
     })
 
-    // Check if HomeView is included in the template
-    expect(wrapper.html()).toContain('home-view-stub')
+    // With shallowMount, RouterView should be stubbed
+    expect(wrapper.findComponent({ name: 'router-view' }).exists()).toBe(true)
+  })
+
+  it('contains router-view when fully mounted', () => {
+    const wrapper = mount(App, {
+      global: {
+        stubs: {
+          RouterView: true,
+        },
+      },
+    })
+
+    // Check if router-view is included in the template
+    expect(wrapper.html()).toContain('router-view-stub')
   })
 })

--- a/src/__tests__/MapComponent.spec.ts
+++ b/src/__tests__/MapComponent.spec.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import MapComponent from '../components/MapComponent.vue'
+import * as markerService from '../services/markerService'
+
+// Mock the vue-router
+const mockRouterPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockRouterPush,
+  })),
+}))
+
+// Mock the markerService
+vi.mock('../services/markerService', async () => {
+  const actual = await vi.importActual('../services/markerService')
+  return {
+    ...actual,
+    startFetching: vi.fn(),
+    stopFetching: vi.fn(),
+    startFetchingByName: vi.fn(),
+    fetchMarkerByName: vi.fn(),
+    // Make sure currentName is properly mocked
+    currentName: actual.currentName,
+  }
+})
+
+describe('MapComponent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    // Set up mock data for markers
+    markerService.markers.value = [
+      {
+        name: 'test',
+        latitude: 1.12345,
+        longitude: 2.12345,
+        timestamp: '2023-01-01T00:00:00Z',
+      },
+    ]
+    markerService.isLoading.value = false
+    markerService.error.value = null
+    markerService.currentName.value = null
+
+    // Mock Element.prototype.getBoundingClientRect
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 500,
+      height: 500,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      x: 0,
+      y: 0,
+      toJSON: vi.fn(),
+    }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initialization', () => {
+    it('should start fetching all markers when no name is provided', async () => {
+      mount(MapComponent, {
+        props: {
+          name: undefined,
+        },
+      })
+
+      await nextTick()
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).not.toHaveBeenCalled()
+    })
+
+    it('should start fetching by name when a name is provided', async () => {
+      mount(MapComponent, {
+        props: {
+          name: 'test',
+        },
+      })
+
+      await nextTick()
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test')
+      expect(markerService.startFetching).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('watch function for name prop', () => {
+    it('should update fetching when name prop changes from null to a value', async () => {
+      const wrapper = mount(MapComponent, {
+        props: {
+          name: undefined,
+        },
+      })
+
+      // Reset mocks after initial mount
+      vi.resetAllMocks()
+
+      // Update the name prop
+      await wrapper.setProps({ name: 'test' })
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test')
+      expect(markerService.startFetching).not.toHaveBeenCalled()
+    })
+
+    it('should update fetching when name prop changes from a value to null', async () => {
+      const wrapper = mount(MapComponent, {
+        props: {
+          name: 'test',
+        },
+      })
+
+      // Reset mocks after initial mount
+      vi.resetAllMocks()
+
+      // Update the name prop
+      await wrapper.setProps({ name: undefined })
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).not.toHaveBeenCalled()
+    })
+
+    it('should update fetching when name prop changes from one value to another', async () => {
+      const wrapper = mount(MapComponent, {
+        props: {
+          name: 'test1',
+        },
+      })
+
+      // Reset mocks after initial mount
+      vi.resetAllMocks()
+
+      // Update the name prop
+      await wrapper.setProps({ name: 'test2' })
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test2')
+      expect(markerService.startFetching).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cleanup', () => {
+    it('should stop fetching when component is unmounted', async () => {
+      const wrapper = mount(MapComponent)
+
+      // Reset mocks after initial mount
+      vi.resetAllMocks()
+
+      // Unmount the component
+      wrapper.unmount()
+
+      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('navigation', () => {
+    it('should navigate to user page when navigateTo is called with a name', async () => {
+      // Reset the mock before the test
+      mockRouterPush.mockReset()
+
+      const wrapper = mount(MapComponent)
+
+      // Call the navigateTo method with a name
+      await wrapper.vm.navigateTo('test')
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/test')
+    })
+
+    it('should navigate to home page when navigateTo is called with null', async () => {
+      // Reset the mock before the test
+      mockRouterPush.mockReset()
+
+      const wrapper = mount(MapComponent)
+
+      // Call the navigateTo method with null
+      await wrapper.vm.navigateTo(null)
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/')
+    })
+  })
+})

--- a/src/__tests__/markerService.spec.ts
+++ b/src/__tests__/markerService.spec.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  currentName,
+  error,
+  fetchMarkerByName,
+  fetchMarkerData,
+  isLoading,
+  markers,
+  startFetching,
+  startFetchingByName,
+  stopFetching,
+} from '../services/markerService'
+
+// Mock fetch API
+global.fetch = vi.fn()
+
+// Mock setInterval and clearInterval
+vi.stubGlobal(
+  'setInterval',
+  vi.fn(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)),
+)
+vi.stubGlobal('clearInterval', vi.fn())
+
+describe('markerService', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.resetAllMocks()
+
+    // Reset reactive state
+    markers.value = []
+    isLoading.value = false
+    error.value = null
+    currentName.value = null
+
+    // Mock successful fetch response
+    const mockResponse = {
+      ok: true,
+      json: vi
+        .fn()
+        .mockResolvedValue([
+          { name: 'test', latitude: 1, longitude: 1, timestamp: '2023-01-01T00:00:00Z' },
+        ]),
+    }
+
+    // @ts-ignore - TypeScript doesn't know we're mocking fetch
+    global.fetch.mockResolvedValue(mockResponse)
+  })
+
+  afterEach(() => {
+    // Clean up after each test
+    vi.restoreAllMocks()
+  })
+
+  describe('fetchMarkerData', () => {
+    it('should fetch marker data from the API', async () => {
+      await fetchMarkerData()
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(markers.value.length).toBe(1)
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('should handle API errors', async () => {
+      // Mock a failed response
+      // @ts-ignore - TypeScript doesn't know we're mocking fetch
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+      await fetchMarkerData()
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(error.value).not.toBe(null)
+      expect(isLoading.value).toBe(false)
+    })
+  })
+
+  describe('fetchMarkerByName', () => {
+    it('should fetch marker data for a specific name', async () => {
+      await fetchMarkerByName('test')
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/test'))
+      expect(markers.value.length).toBe(1)
+      expect(currentName.value).toBe('test')
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('should handle API errors', async () => {
+      // Mock a failed response
+      // @ts-ignore - TypeScript doesn't know we're mocking fetch
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+      await fetchMarkerByName('nonexistent')
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(error.value).toBe('No user named "nonexistent" known...')
+      expect(markers.value.length).toBe(0)
+      expect(isLoading.value).toBe(false)
+    })
+  })
+
+  describe('startFetching', () => {
+    it('should fetch data initially and set up an interval', async () => {
+      await startFetching()
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(setInterval).toHaveBeenCalledTimes(1)
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 10000)
+    })
+
+    it('should use the provided interval', async () => {
+      await startFetching(5000)
+
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 5000)
+    })
+  })
+
+  describe('startFetchingByName', () => {
+    it('should fetch data for a specific name initially and set up an interval', async () => {
+      await startFetchingByName('test')
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/test'))
+      expect(setInterval).toHaveBeenCalledTimes(1)
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 10000)
+    })
+
+    it('should use the provided interval', async () => {
+      await startFetchingByName('test', 5000)
+
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 5000)
+    })
+  })
+
+  describe('stopFetching', () => {
+    it('should clear the interval', async () => {
+      // Set up an interval first
+      await startFetching()
+
+      // Then stop it
+      stopFetching()
+
+      // Called on start, and once in test
+      expect(clearInterval).toHaveBeenCalledTimes(2)
+    })
+
+    it('should do nothing if no interval is set', () => {
+      // Call stopFetching without setting up an interval first
+      stopFetching()
+
+      expect(clearInterval).not.toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -39,5 +39,5 @@ a,
 }
 
 .rounded-icon {
-  border-radius: 50%
+  border-radius: 50%;
 }

--- a/src/components/__tests__/MapComponent.spec.ts
+++ b/src/components/__tests__/MapComponent.spec.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
 import MapComponent from '../MapComponent.vue'
 import type { MarkerData } from '@/services/markerService.ts'
+
+// Mock vue-router
+const mockRouterPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockRouterPush,
+  })),
+}))
 
 // Mock the marker service
 vi.mock('@/services/markerService', () => {
@@ -28,9 +36,12 @@ vi.mock('@/services/markerService', () => {
     ]),
     isLoading: createMockRef(false),
     error: createMockRef(null),
+    currentName: createMockRef(null),
     startFetching: vi.fn(),
     stopFetching: vi.fn(),
     fetchMarkerData: vi.fn(),
+    fetchMarkerByName: vi.fn(),
+    startFetchingByName: vi.fn(),
   }
 })
 
@@ -103,7 +114,7 @@ describe('MapComponent', () => {
 
     // Check if the component renders correctly
     expect(wrapper.find('.map-container').exists()).toBe(true)
-    expect(wrapper.find('h2').text()).toBe('Stalking...')
+    expect(wrapper.find('h2').text()).toBe('Stalking... everyone')
     expect(wrapper.find('.map').exists()).toBe(true)
   })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
 const app = createApp(App)
-
+app.use(router)
 app.mount('#app')

--- a/src/router/__tests__/index.spec.ts
+++ b/src/router/__tests__/index.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import router from '../index'
+import { createWebHistory } from 'vue-router'
+
+// Mock vue-router components
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router')
+  return {
+    ...actual,
+    createRouter: vi.fn().mockImplementation((options) => {
+      return {
+        options,
+        push: vi.fn(),
+        beforeEach: vi.fn(),
+        afterEach: vi.fn(),
+      }
+    }),
+    createWebHistory: vi.fn(),
+  }
+})
+
+// Reset mocks before each test
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// Mock the HomeView component
+vi.mock('../views/HomeView.vue', () => ({
+  default: { name: 'HomeView' }
+}))
+
+describe('Router', () => {
+  it('should have the correct routes configuration', () => {
+    // Get the routes from the router
+    const routes = router.options.routes
+
+    // Check if there are 2 routes
+    expect(routes.length).toBe(2)
+
+    // Check the home route
+    expect(routes[0]).toMatchObject({
+      path: '/',
+      name: 'home',
+      props: { name: undefined },
+    })
+
+    // Check the user route
+    expect(routes[1]).toMatchObject({
+      path: '/:name',
+      name: 'user',
+      props: true,
+    })
+  })
+
+  it('should have the correct history mode configuration', () => {
+    // Since we're mocking the router and the actual call to createWebHistory happens
+    // when the module is imported, we can't easily test that createWebHistory was called.
+    // Instead, we'll verify that the router is properly exported
+    expect(router).toBeDefined()
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,22 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: HomeView,
+      props: { name: undefined },
+    },
+    {
+      path: '/:name',
+      name: 'user',
+      component: HomeView,
+      props: true,
+    },
+  ],
+})
+
+export default router

--- a/src/services/__tests__/markerService.spec.ts
+++ b/src/services/__tests__/markerService.spec.ts
@@ -81,7 +81,7 @@ describe('markerService', () => {
     expect(error.value).toBe('Network error')
   })
 
-  it('starts and stops periodic fetching', () => {
+  it('starts and stops periodic fetching', async () => {
     // Mock the global functions
     const originalSetInterval = global.setInterval
     const originalClearInterval = global.clearInterval
@@ -97,7 +97,7 @@ describe('markerService', () => {
 
     try {
       // Call the functions we want to test
-      startFetching(5000)
+      await startFetching(5000)
 
       // Verify that setInterval was called with the correct interval
       expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 5000)

--- a/src/services/markerService.ts
+++ b/src/services/markerService.ts
@@ -15,6 +15,7 @@ const apiEndpoint = import.meta.env.VITE_API_ENDPOINT as string
 export const markers = ref<MarkerData[]>([])
 export const isLoading = ref(false)
 export const error = ref<string | null>(null)
+export const currentName = ref<string | null>(null)
 
 // Fetch marker data from the API
 export const fetchMarkerData = async (): Promise<void> => {
@@ -38,21 +39,60 @@ export const fetchMarkerData = async (): Promise<void> => {
   }
 }
 
-// Set up periodic data fetching
-let fetchInterval: number | null = null
+// Fetch marker data for a specific name
+export const fetchMarkerByName = async (name: string): Promise<void> => {
+  isLoading.value = true
+  error.value = null
+  currentName.value = name
 
-// Start periodic fetching
-export const startFetching = (intervalMs = 10000): void => {
+  try {
+    const response = await fetch(`${apiEndpoint}/${name}`)
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`No user named "${name}" known...`)
+      }
+      throw new Error(`API request failed with status ${response.status}`)
+    }
+
+    const data = await response.json()
+    // If the API returns a single object, wrap it in an array
+    markers.value = Array.isArray(data) ? data : [data]
+  } catch (err) {
+    console.error(`Error fetching marker data for ${name}:`, err)
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred'
+    markers.value = [] // Clear markers on error
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Set up periodic data fetching
+let fetchInterval: ReturnType<typeof setTimeout> | null = null
+
+// Start periodic fetching for all markers
+export const startFetching = async (intervalMs = 10000): Promise<void> => {
+  stopFetching()
   // Initial fetch
-  fetchMarkerData()
+  await fetchMarkerData()
 
   // Set up interval for periodic fetching
-  fetchInterval = setInterval(fetchMarkerData, intervalMs) as unknown as number
+  fetchInterval = setInterval(fetchMarkerData, intervalMs)
+}
+
+// Start periodic fetching for a specific name
+export const startFetchingByName = async (name: string, intervalMs = 10000): Promise<void> => {
+  stopFetching()
+  // Initial fetch
+  await fetchMarkerByName(name)
+
+  // Set up interval for periodic fetching
+  fetchInterval = setInterval(async () => await fetchMarkerByName(name), intervalMs)
 }
 
 // Stop periodic fetching
 export const stopFetching = (): void => {
-  if (fetchInterval !== null) {
+  if (fetchInterval) {
     clearInterval(fetchInterval)
     fetchInterval = null
   }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import MapComponent from '../components/MapComponent.vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
 </script>
 
 <template>
   <main class="home-view">
-    <MapComponent />
+    <MapComponent :name="route.params.name as string" />
   </main>
 </template>
 

--- a/src/views/__tests__/HomeView.spec.ts
+++ b/src/views/__tests__/HomeView.spec.ts
@@ -1,33 +1,76 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
 import { h } from 'vue'
 import HomeView from '../HomeView.vue'
-import MapComponent from '../../components/MapComponent.vue'
+import type { RouteLocationNormalizedGeneric } from 'vue-router'
+import { useRoute } from 'vue-router'
 
 // Mock the MapComponent to isolate HomeView testing
 vi.mock('../../components/MapComponent.vue', () => ({
   default: {
     name: 'MapComponent',
+    props: ['name'],
     render() {
-      return h('div', { class: 'mock-map-component' }, 'Mocked Map Component')
+      return h(
+        'div',
+        { class: 'mock-map-component' },
+        `Mocked Map Component: ${this.name || 'no name'}`,
+      )
     },
   },
 }))
 
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(),
+}))
+
 describe('HomeView', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks()
+  })
+
   it('renders properly with shallow mount', () => {
+    // Mock useRoute to return a route with no name parameter
+    vi.mocked(useRoute).mockReturnValue({
+      params: {},
+      path: '/',
+      name: 'home',
+      fullPath: '/',
+      query: {},
+      hash: '',
+      matched: [],
+      meta: {},
+      redirectedFrom: undefined,
+    } as RouteLocationNormalizedGeneric)
+
     const wrapper = shallowMount(HomeView)
 
     // Check if the component renders correctly
     expect(wrapper.find('main').exists()).toBe(true)
 
     // With shallowMount, MapComponent should be stubbed
-    expect(wrapper.findComponent({ name: 'MapComponent' }).exists()).toBe(true)
+    const mapComponent = wrapper.findComponent({ name: 'MapComponent' })
+    expect(mapComponent.exists()).toBe(true)
+    expect(mapComponent.props('name')).toBe(undefined)
   })
 
   it('contains MapComponent when fully mounted', async () => {
-    // For this test, we'll use a different approach since we mocked the component
-    // We'll check if the component tries to render MapComponent
+    // Mock useRoute to return a route with no name parameter
+    vi.mocked(useRoute).mockReturnValue({
+      params: {
+        name: '',
+      },
+      path: '/',
+      name: 'home',
+      fullPath: '/',
+      query: {},
+      hash: '',
+      matched: [],
+      meta: {},
+      redirectedFrom: undefined,
+    } as RouteLocationNormalizedGeneric)
 
     const wrapper = mount(HomeView, {
       global: {
@@ -39,5 +82,29 @@ describe('HomeView', () => {
 
     // Check if MapComponent is included in the template
     expect(wrapper.html()).toContain('map-component-stub')
+  })
+
+  it('passes route params to MapComponent', () => {
+    // Mock useRoute to return a route with a specific name parameter
+    vi.mocked(useRoute).mockReturnValue({
+      params: {
+        name: 'testuser',
+      },
+      path: '/testuser',
+      name: 'user',
+      fullPath: '/testuser',
+      query: {},
+      hash: '',
+      matched: [],
+      meta: {},
+      redirectedFrom: undefined,
+    } as RouteLocationNormalizedGeneric)
+
+    const wrapper = shallowMount(HomeView)
+
+    // Check if MapComponent receives the name prop
+    const mapComponent = wrapper.findComponent({ name: 'MapComponent' })
+    expect(mapComponent.exists()).toBe(true)
+    expect(mapComponent.props('name')).toBe('testuser')
   })
 })


### PR DESCRIPTION
This commit changes the way that the map markers are fetched based on a new prop that allows for the fetching of specific names instead of all markers.

The commit also adds a new navigation feature that allows users to view markers from a specific name and also shows the markers from all names when clicking the "View All" button.