### PR TITLE
feat(map): implement live update mode using WebSocket

### DIFF
--- a/src/__tests__/MapComponent.spec.ts
+++ b/src/__tests__/MapComponent.spec.ts
@@ -17,12 +17,21 @@ vi.mock('../services/markerService', async () => {
   const actual = await vi.importActual('../services/markerService')
   return {
     ...actual,
+    // Keep reactive refs and enums from actual
+    updateMode: actual.updateMode,
+    UpdateMode: actual.UpdateMode,
+    currentName: actual.currentName,
+    markers: actual.markers,
+    isLoading: actual.isLoading,
+    error: actual.error,
+    // Mock methods
     startFetching: vi.fn(),
     stopFetching: vi.fn(),
     startFetchingByName: vi.fn(),
     fetchMarkerByName: vi.fn(),
-    // Make sure currentName is properly mocked
-    currentName: actual.currentName,
+    startLive: vi.fn(),
+    startLiveByName: vi.fn(),
+    stopUpdates: vi.fn(),
   }
 })
 
@@ -62,7 +71,7 @@ describe('MapComponent', () => {
   })
 
   describe('initialization', () => {
-    it('should start fetching all markers when no name is provided', async () => {
+    it('should start live updates when no name is provided', async () => {
       mount(MapComponent, {
         props: {
           name: undefined,
@@ -71,12 +80,12 @@ describe('MapComponent', () => {
 
       await nextTick()
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).not.toHaveBeenCalled()
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
+      expect(markerService.startLive).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).not.toHaveBeenCalled()
     })
 
-    it('should start fetching by name when a name is provided', async () => {
+    it('should start live updates by name when a name is provided', async () => {
       mount(MapComponent, {
         props: {
           name: 'test',
@@ -85,15 +94,15 @@ describe('MapComponent', () => {
 
       await nextTick()
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test')
-      expect(markerService.startFetching).not.toHaveBeenCalled()
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledWith('test')
+      expect(markerService.startLive).not.toHaveBeenCalled()
     })
   })
 
   describe('watch function for name prop', () => {
-    it('should update fetching when name prop changes from null to a value', async () => {
+    it('should update live updates when name prop changes from null to a value', async () => {
       const wrapper = mount(MapComponent, {
         props: {
           name: undefined,
@@ -106,13 +115,13 @@ describe('MapComponent', () => {
       // Update the name prop
       await wrapper.setProps({ name: 'test' })
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test')
-      expect(markerService.startFetching).not.toHaveBeenCalled()
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledWith('test')
+      expect(markerService.startLive).not.toHaveBeenCalled()
     })
 
-    it('should update fetching when name prop changes from a value to null', async () => {
+    it('should update live updates when name prop changes from a value to null', async () => {
       const wrapper = mount(MapComponent, {
         props: {
           name: 'test',
@@ -125,12 +134,12 @@ describe('MapComponent', () => {
       // Update the name prop
       await wrapper.setProps({ name: undefined })
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).not.toHaveBeenCalled()
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
+      expect(markerService.startLive).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).not.toHaveBeenCalled()
     })
 
-    it('should update fetching when name prop changes from one value to another', async () => {
+    it('should update live updates when name prop changes from one value to another', async () => {
       const wrapper = mount(MapComponent, {
         props: {
           name: 'test1',
@@ -143,15 +152,15 @@ describe('MapComponent', () => {
       // Update the name prop
       await wrapper.setProps({ name: 'test2' })
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledTimes(1)
-      expect(markerService.startFetchingByName).toHaveBeenCalledWith('test2')
-      expect(markerService.startFetching).not.toHaveBeenCalled()
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledTimes(1)
+      expect(markerService.startLiveByName).toHaveBeenCalledWith('test2')
+      expect(markerService.startLive).not.toHaveBeenCalled()
     })
   })
 
   describe('cleanup', () => {
-    it('should stop fetching when component is unmounted', async () => {
+    it('should stop updates when component is unmounted', async () => {
       const wrapper = mount(MapComponent)
 
       // Reset mocks after initial mount
@@ -160,7 +169,7 @@ describe('MapComponent', () => {
       // Unmount the component
       wrapper.unmount()
 
-      expect(markerService.stopFetching).toHaveBeenCalledTimes(1)
+      expect(markerService.stopUpdates).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/components/__tests__/MapComponent.spec.ts
+++ b/src/components/__tests__/MapComponent.spec.ts
@@ -19,13 +19,17 @@ vi.mock('@/services/markerService', () => {
     __v_isRef: true as const,
   })
 
-  // Define ZoomLevel enum for the mock
+  // Define enums and constants for the mock
   const ZoomLevel = {
     Close: 18,
     Medium: 15,
     Far: 10,
     VeryFar: 6,
   }
+  const UpdateMode = {
+    Poll: 'poll',
+    Live: 'live',
+  } as const
 
   return {
     markers: createMockRef<Array<MarkerData>>([
@@ -48,15 +52,25 @@ vi.mock('@/services/markerService', () => {
     freeRoamingMode: createMockRef(false),
     updateFrequency: createMockRef(5000),
     currentZoomLevel: createMockRef(ZoomLevel.Medium),
+    updateMode: createMockRef(UpdateMode.Live),
     ZoomLevel,
+    UpdateMode,
+    // Polling APIs (kept for backward compatibility in tests)
     startFetching: vi.fn(),
     stopFetching: vi.fn(),
     fetchMarkerData: vi.fn(),
     fetchMarkerByName: vi.fn(),
     startFetchingByName: vi.fn(),
+    // Live mode APIs
+    startLive: vi.fn(),
+    startLiveByName: vi.fn(),
+    stopLive: vi.fn(),
+    stopUpdates: vi.fn(),
+    // UI control helpers
     toggleFreeRoamingMode: vi.fn(),
     setUpdateFrequency: vi.fn(),
     setZoomLevel: vi.fn(),
+    setUpdateMode: vi.fn(),
   }
 })
 
@@ -190,9 +204,9 @@ describe('MapComponent', () => {
       expect.any(Object),
     )
 
-    // Should start fetching data
+    // Should start live updates by default
     const markerService = await import('@/services/markerService')
-    expect(markerService.startFetching).toHaveBeenCalled()
+    expect(markerService.startLive).toHaveBeenCalled()
   })
 
   it('cleans up the map and stops fetching when unmounted', async () => {
@@ -207,8 +221,8 @@ describe('MapComponent', () => {
     const mapInstance = vi.mocked(L.default.map).mock.results[0]!.value as any
     expect(mapInstance.remove).toHaveBeenCalled()
 
-    // Should stop fetching data
+    // Should stop updates
     const markerService = await import('@/services/markerService')
-    expect(markerService.stopFetching).toHaveBeenCalled()
+    expect(markerService.stopUpdates).toHaveBeenCalled()
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,11 @@ export default defineConfig(({ mode }) => {
           // If your API endpoint doesn't start with /api, you can rewrite the path:
           // rewrite: (path) => path.replace(/^\/api/, '')
         },
+        '/ws': {
+          target: env.VITE_DEV_PROXY_TARGET,
+          changeOrigin: true,
+          ws: true,
+        },
       },
     },
   }


### PR DESCRIPTION
- Added `Live` mode toggle to enable real-time updates via WebSocket.
- Integrated WebSocket-based marker updates alongside existing polling mechanism.
- Refactored existing update logic to handle switching between `Poll` and `Live` modes.
- Updated UI with a `LIVE` toggle button and disabled unsupported controls in `Live` mode.
- Enhanced tests to accommodate the `Live` mode and validate update flow.